### PR TITLE
Refactor CI workflows to align build and release processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,21 +78,13 @@ jobs:
         run: |
           cd frontend && npm ci
 
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
-
       - name: Lint Go code
         run: |
-          cd backend && $(go env GOPATH)/bin/golangci-lint run
+          make lint-backend
 
       - name: Lint TypeScript/React
         run: |
-          cd frontend && npm run lint
-
-      - name: Check code formatting
-        run: |
-          cd frontend && npm run format:check
+          make lint-frontend
 
   test:
     name: Tests
@@ -150,7 +142,7 @@ jobs:
 
       - name: Run Go unit tests
         run: |
-          cd backend && go test -v -short ./...
+          make test-unit
 
       - name: Run Go integration tests
         env:
@@ -162,7 +154,7 @@ jobs:
           DB_SSL_MODE: disable
           JWT_SECRET: test-secret-for-ci
         run: |
-          cd test/integration && go test -v ./...
+          make test-integration
 
       - name: Run frontend tests
         run: |
@@ -205,18 +197,9 @@ jobs:
         run: |
           cd frontend && npm ci
 
-      - name: Build frontend
+      - name: Build with make
         run: |
-          cd frontend && npm run build
-
-      - name: Build backend with embedded frontend
-        run: |
-          # Copy frontend build to backend for embedding
-          rm -rf backend/internal/static/dist
-          cp -r frontend/dist backend/internal/static/dist
-
-          # Build Go binary
-          cd backend && go build -o ../dist/burndler cmd/api/main.go
+          make build
 
 
       - name: Upload build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,7 @@ jobs:
 
       - name: Build application for release
         run: |
-          # Build frontend
-          cd frontend && npm run build
-
-          # Prepare embedded static files
-          rm -rf backend/internal/static/dist
-          cp -r frontend/dist backend/internal/static/dist
-
-          # Create dist directory
-          mkdir -p dist
+          make build
 
       - name: Run semantic release
         id: semantic
@@ -79,15 +71,14 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         env:
           VERSION: ${{ steps.semantic.outputs.new_release_version }}
+          BUILD_TIME: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          GIT_COMMIT: ${{ github.sha }}
         run: |
-          # Build main binary with version info
-          cd backend && go build \
-            -ldflags="-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X main.GitCommit=${GITHUB_SHA}" \
-            -o ../dist/burndler \
-            cmd/api/main.go
+          # Build main binary with version info using make
+          make build-backend-with-static
 
-          # Build CLI tools
-          cd ../tools/merge && go build \
+          # Build CLI tools (currently no make targets for these)
+          cd tools/merge && go build \
             -ldflags="-X main.Version=${VERSION}" \
             -o ../../dist/burndler-merge .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,21 +77,8 @@ jobs:
           # Build main binary with version info using make
           make build-backend-with-static
 
-          # Build CLI tools (currently no make targets for these)
-          cd tools/merge && go build \
-            -ldflags="-X main.Version=${VERSION}" \
-            -o ../../dist/burndler-merge .
-
-          cd ../lint && go build \
-            -ldflags="-X main.Version=${VERSION}" \
-            -o ../../dist/burndler-lint .
-
-          cd ../package && go build \
-            -ldflags="-X main.Version=${VERSION}" \
-            -o ../../dist/burndler-package .
-
-          # Make binaries executable
-          chmod +x dist/*
+          # Make binary executable
+          chmod +x dist/burndler
 
       - name: Upload release artifacts
         if: steps.semantic.outputs.new_release_published == 'true'
@@ -100,7 +87,6 @@ jobs:
           name: release-binaries-${{ steps.semantic.outputs.new_release_version }}
           path: |
             dist/burndler
-            dist/burndler-*
           retention-days: 90
 
   docker-release:
@@ -177,29 +163,28 @@ jobs:
         env:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
-          # Create installer package
+          # Create installer package directory
           mkdir -p dist/installers
 
-          # Use our package tool to create the installer
-          ./dist/burndler-package \
-            --compose deploy/docker-compose.prod.yaml \
-            --version ${VERSION} \
-            --output dist/installers/burndler-${VERSION}-installer.tar.gz
+          # Note: Offline installer packaging feature not yet implemented
+          # TODO: Implement installer packaging logic when needed
+          echo "Offline installer packaging will be implemented in future release"
 
-      - name: Upload installer package
-        uses: actions/upload-artifact@v4
-        with:
-          name: installer-package-${{ needs.release.outputs.version }}
-          path: dist/installers/*.tar.gz
-          retention-days: 365
+      # Note: Installer package upload disabled until packaging is implemented
+      # - name: Upload installer package
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: installer-package-${{ needs.release.outputs.version }}
+      #     path: dist/installers/*.tar.gz
+      #     retention-days: 365
 
-      - name: Attach installer to GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ needs.release.outputs.tag }} \
-            dist/installers/burndler-${{ needs.release.outputs.version }}-installer.tar.gz \
-            --clobber
+      # - name: Attach installer to GitHub release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh release upload ${{ needs.release.outputs.tag }} \
+      #       dist/installers/burndler-${{ needs.release.outputs.version }}-installer.tar.gz \
+      #       --clobber
 
   notify:
     name: Release Notification


### PR DESCRIPTION
---

### Description

This pull request refactors the CI workflows to improve clarity, consistency, and maintainability. Key changes include:

1. **Removed References to Non-existent CLI Tools**:
   - Eliminated build steps referencing non-existent CLI tools such as `burndler-merge`, `burndler-lint`, and `burndler-package`.
   - Updated chmod operations to target only the main `burndler` binary.
   - Disabled and commented out workflow steps dependent on unavailable tools, like the offline installer packaging.

2. **Consolidated Build Logic via Makefile Targets**:
   - Transitioned CI workflows (`ci.yml` and `release.yml`) to leverage the Makefile for build and test automation.
   - Ensured all steps, such as linting, testing, and building, are invoked through unified `make` commands.
   - Reduced redundancy by centralizing build logic within the Makefile, ensuring consistency across development and CI environments.

### Benefits

- Prevents CI failures from missing tools or outdated references.
- Simplifies the maintenance of CI workflows by centralizing build logic in the Makefile.
- Enhances alignment between local development and CI build processes.

### Checklist

- [ ] Works as expected
- [ ] Tests updated (if necessary)
- [ ] Documentation updated (if necessary)