### PR TITLE
Fix CI initialization and ensure default test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,10 @@ jobs:
         run: |
           cd frontend && npm ci
 
+      - name: Initialize build environment
+        run: |
+          make init
+
       - name: Build with make
         run: |
           make build

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	// Clear environment variables to test actual defaults
+	_ = os.Unsetenv("DB_NAME")
+
 	// Test default values
 	cfg := Load()
 


### PR DESCRIPTION
```
### Description

This pull request addresses the following:

- **Fix CI build failure**: Adds a `make init` step to the CI pipeline to initialize the build environment. This ensures consistency with the local development setup by creating the required `.initialized` marker file before running `make build`.
  
- **Improve test reliability**: Updates `TestLoad` in the configuration tests to clear environment variables. This change ensures default values are properly tested regardless of the execution environment.

### Related Issues
_No related issues were found for this pull request._

### Checklist

- [ ] Tests have been added or updated where necessary.
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Code changes adhere to project coding standards and conventions.
```