### PR TITLE
Improve CI and Release workflow integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - main
-      - develop # for testing releases
+      - develop
 
 env:
   GO_VERSION: '1.24'
@@ -17,25 +20,10 @@ permissions:
   packages: write
 
 jobs:
-  wait-for-ci:
-    name: Wait for CI Completion
-    runs-on: ubuntu-latest
-    if: github.repository == 'starpia-forge/burndler'
-    steps:
-      - name: Wait for CI workflow to complete
-        uses: lewagon/wait-on-check-action@v1.3.4
-        with:
-          ref: ${{ github.sha }}
-          check-name: 'Build'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
-
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    needs: wait-for-ci
-    if: github.repository == 'starpia-forge/burndler'
+    if: github.repository == 'starpia-forge/burndler' && github.event.workflow_run.conclusion == 'success'
     outputs:
       released: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.sha }}
-          check-name: 'CI'
+          check-name: 'Build'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
           allowed-conclusions: success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
           cd frontend && npm ci
           cd ../backend && go mod download
 
+      - name: Initialize build environment
+        run: |
+          make init
+
       - name: Build application for release
         run: |
           make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop # for testing releases
 
 env:
   GO_VERSION: '1.24'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,24 @@ permissions:
   packages: write
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI Completion
+    runs-on: ubuntu-latest
+    if: github.repository == 'starpia-forge/burndler'
+    steps:
+      - name: Wait for CI workflow to complete
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'CI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    needs: wait-for-ci
     if: github.repository == 'starpia-forge/burndler'
     outputs:
       released: ${{ steps.semantic.outputs.new_release_published }}


### PR DESCRIPTION
### Description of Changes

This pull request enhances the integration of CI and Release workflows to ensure reliability and consistency in the deployment pipeline. Key changes include:

- **Workflow Integration:**
  - Replaced the problematic `wait-on-check-action` with GitHub Actions' `workflow_run` event to ensure Release workflow triggers only after successful CI completion.
  - Added an explicit dependency on the completed CI workflow, preventing releases if CI fails.

- **Bug Fixes:**
  - Corrected the referenced check name in CI wait from 'CI' to 'Build', resolving errors caused by incorrect job references.
  - Added a `make init` step in the Release workflow to ensure proper build environment initialization.

- **Other Improvements:**
  - Included the `develop` branch in the Release workflow for testing purposes.

These changes address issues where broken code could inadvertently be released or workflows failed due to misconfigured dependencies. Only successfully tested and validated code will proceed to release.